### PR TITLE
Prevents traceback (below) that happened when canceling the adding font dialog

### DIFF
--- a/OverlayUFOs/Overlay UFOs.roboFontExt/lib/OverlayUFOs.py
+++ b/OverlayUFOs/Overlay UFOs.roboFontExt/lib/OverlayUFOs.py
@@ -255,6 +255,8 @@ class ViewSourceFontsDialog(BaseWindowController, ViewSourceFonts):
     
     def addPathCallback(self, sender):
         f = OpenFont(None, showUI=False)
+        if f is None: # Cancel button was hit, or Escape key was pressed
+        	return
         sources = self.getSources()
         if type(f) is not list:
             f = [f]


### PR DESCRIPTION
Traceback (most recent call last):
  File "OverlayUFOs.py", line 114, in drawSourceFonts
AttributeError: 'NoneType' object has no attribute 'has_key'