### PR TITLE
Update info.plist syntax to use nested Mechanic keys

### DIFF
--- a/Accentista/Accentista.roboFontExt/info.plist
+++ b/Accentista/Accentista.roboFontExt/info.plist
@@ -29,12 +29,12 @@
 	<real>1</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>Accentista/Accentista.roboFontExt</string>
-	<key>summary</key>
-	<string>Overlay combining or floating accents over the Current Glyph, based on the name and position of the anchors.</string>
-
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>Overlay combining or floating accents over the Current Glyph, based on the name and position of the anchors.</string>
+	</dict>
 </dict>
 </plist>

--- a/AdjustMetrics/AdjustMetrics.roboFontExt/info.plist
+++ b/AdjustMetrics/AdjustMetrics.roboFontExt/info.plist
@@ -29,12 +29,12 @@
 	<real>1340333208.607609</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>AdjustMetrics/AdjustMetrics.roboFontExt</string>
-	<key>summary</key>
-	<string>Adjust the left margin, right margin, or both, with options for which glyphs in which fonts, and what to do with those pesky components.</string>
-
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>Adjust the left margin, right margin, or both, with options for which glyphs in which fonts, and what to do with those pesky components.</string>
+	</dict>
 </dict>
 </plist>

--- a/BoundingTool/BoundingTool.roboFontExt/info.plist
+++ b/BoundingTool/BoundingTool.roboFontExt/info.plist
@@ -20,11 +20,12 @@
 	<integer>1</integer>
 	<key>version</key>
 	<string>2.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>BoundingTool/BoundingTool.roboFontExt</string>
-	<key>summary</key>
-	<string>An editing tool that also helps you visualize the bounding box of your current glyph or selection.</string>
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>An editing tool that also helps you visualize the bounding box of your current glyph or selection.</string>
+	</dict>
 </dict>
 </plist>

--- a/GlyphSelect/Glyph Select.roboFontExt/info.plist
+++ b/GlyphSelect/Glyph Select.roboFontExt/info.plist
@@ -29,11 +29,14 @@
 	<real>1338009990.8311591</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>GlyphSelect/Glyph Select.roboFontExt</string>
-	<key>summary</key>
-	<string>Search for glyphs using a variety of parameters, such as glyph name, base name, suffix, unicode, and unicode category.</string>
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>extensionPath</key>
+		<string>GlyphSelect/Glyph Select.roboFontExt</string>
+		<key>summary</key>
+		<string>Search for glyphs using a variety of parameters, such as glyph name, base name, suffix, unicode, and unicode category.</string>
+	</dict>
 </dict>
 </plist>

--- a/ItalicBowtie/ItalicBowtie.roboFontExt/info.plist
+++ b/ItalicBowtie/ItalicBowtie.roboFontExt/info.plist
@@ -29,11 +29,12 @@
 	<real>1392930656.779417</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>ItalicBowtie/ItalicBowtie.roboFontExt</string>
-	<key>summary</key>
-	<string>Visualize and set italic angle and offset values, and skew and reposition glyphs accordingly.</string>
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>Visualize and set italic angle and offset values, and skew and reposition glyphs accordingly.</string>
+	</dict>
 </dict>
 </plist>

--- a/OverlayUFOs/Overlay UFOs.roboFontExt/info.plist
+++ b/OverlayUFOs/Overlay UFOs.roboFontExt/info.plist
@@ -29,11 +29,12 @@
 	<real>1384253504.0</real>
 	<key>version</key>
 	<string>1.1</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>OverlayUFOs/Overlay UFOs.roboFontExt</string>
-	<key>summary</key>
-	<string>View an overlay of any glyphs from any font behind or beside what you are drawing.</string>
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>View an overlay of any glyphs from any font behind or beside what you are drawing.</string>
+	</dict>
 </dict>
 </plist>

--- a/ShowCharacterInfo/ShowCharacterInfo.roboFontExt/info.plist
+++ b/ShowCharacterInfo/ShowCharacterInfo.roboFontExt/info.plist
@@ -20,11 +20,12 @@
 	<real>1366118749.7201691</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>ShowCharacterInfo/ShowCharacterInfo.roboFontExt</string>
-	<key>summary</key>
-	<string>Unobtrusively display a readout of the unicode character represented by the current glyph, its hex unicode value(s), and unicode name.</string>
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>Unobtrusively display a readout of the unicode character represented by the current glyph, its hex unicode value(s), and unicode name.</string>
+	</dict>
 </dict>
 </plist>

--- a/ShowMouseCoordinates/Show Mouse Coordinates.roboFontExt/info.plist
+++ b/ShowMouseCoordinates/Show Mouse Coordinates.roboFontExt/info.plist
@@ -20,12 +20,12 @@
 	<real>1366118749.7201691</real>
 	<key>version</key>
 	<string>1.0</string>
-	<key>repository</key>
-	<string>FontBureau/fbOpenTools</string>
-	<key>extensionPath</key>
-	<string>ShowMouseCoordinates/Show Mouse Coordinates.roboFontExt</string>
-	<key>summary</key>
-	<string>Get a readout of information about the mouse: its current position, how far it has been dragged, the dragging angle, and the dragging distance.</string>
-
+	<key>com.robofontmechanic.Mechanic</key>
+	<dict>
+		<key>repository</key>
+		<string>FontBureau/fbOpenTools</string>
+		<key>summary</key>
+		<string>Get a readout of information about the mouse: its current position, how far it has been dragged, the dragging angle, and the dragging distance.</string>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
I missed this yesterday, but the summary key only works when it's used with the new nested syntax that uses a namespaced dict. The extensionPath configuration is also no longer necesary, so I've removed those in addition.