### PR TITLE
new RFont doesn't have _object

### DIFF
--- a/AdjustMetrics/AdjustMetrics.roboFontExt/lib/adjustMetrics.py
+++ b/AdjustMetrics/AdjustMetrics.roboFontExt/lib/adjustMetrics.py
@@ -314,7 +314,7 @@ class AdjustMetrics(BaseWindowController):
             if self.w.glyphSelection.get() == 0:
                 gnames = CurrentFont().selection
             else:
-                gnames = f._object.keys()
+                gnames = f.keys()
 
 
             if self.w.adjustBaseComponents.get():


### PR DESCRIPTION
Fix `AttributeError: 'RFont' object has no attribute '_object'`