### PR TITLE
Explicitly setting `m` to a tuple, as is required by FontParts

### DIFF
--- a/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
+++ b/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
@@ -113,7 +113,7 @@ class Italicalc:
         x = math.radians(dx)
         y = math.radians(dy)
         m = m.skew(x,-y)
-        g.transform(m)
+        g.transform(tuple(m))
         top2 = g.box[3]
         bottom2 = g.box[1]
         height2 = top2 + abs(bottom2)


### PR DESCRIPTION
`RGlyph.transform()` (an alias of `RGlyph.transformBy()`) requires a tuple. This pull request changes `m`, an instance of `fontTools.misc.transform.Transform`, into a tuple.