### PR TITLE
Fix AttributeError

### DIFF
--- a/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
+++ b/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
@@ -288,7 +288,7 @@ class ItalicBowtie(BaseWindowController, Italicalc):
             glyphs = []
             for f in fonts:
                 for g in f:
-                    glyphs.append(g.name)
+                    glyphs.append(g)
         
         for glyph in glyphs:
             Italicalc.italicize(glyph, italicAngle, offset=italicSlantOffset, makeReferenceLayer=view.makeReferenceLayer.get())


### PR DESCRIPTION
Previously, choosing “All Glyphs” in the interface resulted in a list of glyph names instead of a list of glyphs. This caused an AttributeError as soon as the first glyph name hit a 'prepareUndo'.