### PR TITLE
Italic Bowtie Subscriber Updates

### DIFF
--- a/ItalicBowtie/ItalicBowtie.roboFontExt/info.plist
+++ b/ItalicBowtie/ItalicBowtie.roboFontExt/info.plist
@@ -34,6 +34,6 @@
 	<key>timeStamp</key>
 	<real>1636728051.4429052</real>
 	<key>version</key>
-	<string>1.2</string>
+	<string>1.3</string>
 </dict>
 </plist>

--- a/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
+++ b/ItalicBowtie/ItalicBowtie.roboFontExt/lib/ItalicBowtie.py
@@ -7,9 +7,9 @@ from vanilla import FloatingWindow, TextBox, EditText
 from vanilla import Button, RadioGroup, CheckBox
 
 from mojo.roboFont import CurrentFont, AllFonts, CurrentGlyph
-from mojo.UI import CurrentGlyphWindow
+from mojo.UI import CurrentGlyphWindow, CurrentWindow
 from mojo.extensions import getExtensionDefault, setExtensionDefault
-from mojo.subscriber import WindowController, Subscriber, registerGlyphEditorSubscriber
+from mojo.subscriber import WindowController, Subscriber, registerRoboFontSubscriber
 
 
 ######################
@@ -136,40 +136,18 @@ def italicize(glyph,
 # THE TOOL #
 ############
 class ItalicBowtie(Subscriber, WindowController):
-
     DEFAULTKEY = 'com.fontbureau.italicBowtie'
     DEFAULTKEY_REFERENCE = DEFAULTKEY + '.drawReferenceGlyph'
     italicSlantOffsetKey = 'com.typemytype.robofont.italicSlantOffset'
 
+    container = None
+    currentGlyph = None
+    currentFont = None
+
     debug = True
 
     def build(self):
-        glyphEditor = self.getGlyphEditor()
-        self.container = glyphEditor.extensionContainer(
-            identifier="com.roboFont.ItalicBowtie.background",
-            location="background",
-            clear=True)
-
-        self.crossHeightLayer = self.container.appendLineSublayer(
-            strokeWidth=1,
-            strokeColor=(.2, .1, .5, .5),
-            strokeDash=(2,)
-        )
-
-        fillColor = (.2, .1, .5, .05)
-        strokeColor = (.2, .1, .5, .5)
-        strokeWidth = 0.5
-        self.leftBowtieLayer = self.container.appendPathSublayer(
-            fillColor=fillColor,
-            strokeColor=strokeColor,
-            strokeWidth=strokeWidth
-        )
-        self.rightBowtieLayer = self.container.appendPathSublayer(
-            fillColor=fillColor,
-            strokeColor=strokeColor,
-            strokeWidth=strokeWidth
-        )
-
+        self.setUpContainers()
         self.w = FloatingWindow((325, 250), "Italic Bowtie")
         self.populateWindow()
 
@@ -177,13 +155,64 @@ class ItalicBowtie(Subscriber, WindowController):
         self.w.open()
 
     def destroy(self):
-        self.container.clearSublayers()
+        if self.container:
+            self.container.clearSublayers()
 
-    def glyphEditorGlyphDidChange(self, info):
-        self.updateBowtie()
+    def roboFontDidSwitchCurrentGlyph(self, info):
+        self.setState()
+        
+    def roboFontDidSwitchCurrentFont(self, info):
+        self.setState()
 
     def glyphEditorDidSetGlyph(self, info):
+        self.destroy()
+        self.setState()
+        self.setUpContainers()
         self.updateBowtie()
+        
+    def setState(self):
+        currentWindow = CurrentWindow()
+        if currentWindow:
+            if hasattr(currentWindow, 'getGlyph'):
+                self.currentGlyph = currentWindow.getGlyph()
+                self.currentFont = self.currentGlyph.font
+            elif hasattr(currentWindow, 'document'):
+                self.currentGlyph = currentWindow.document.getCurrentGlyph()
+                self.currentFont = currentWindow.document.getFont()
+            else:
+                self.currentGlyph = CurrentGlyph()
+                self.currentFont = CurrentFont()
+        else:
+            self.currentGlyph = None
+            self.currentFont = None
+            
+    def setUpContainers(self):
+        glyphEditor = CurrentGlyphWindow()
+        if glyphEditor:
+            self.container = glyphEditor.extensionContainer(
+                identifier="com.roboFont.ItalicBowtie.background",
+                location="background",
+                clear=True)
+
+            self.crossHeightLayer = self.container.appendLineSublayer(
+                strokeWidth=1,
+                strokeColor=(.2, .1, .5, .5),
+                strokeDash=(2,)
+            )
+
+            fillColor = (.2, .1, .5, .05)
+            strokeColor = (.2, .1, .5, .5)
+            strokeWidth = 0.5
+            self.leftBowtieLayer = self.container.appendPathSublayer(
+                fillColor=fillColor,
+                strokeColor=strokeColor,
+                strokeWidth=strokeWidth
+            )
+            self.rightBowtieLayer = self.container.appendPathSublayer(
+                fillColor=fillColor,
+                strokeColor=strokeColor,
+                strokeWidth=strokeWidth
+            )
 
     def populateWindow(self):
         y = 10
@@ -231,29 +260,28 @@ class ItalicBowtie(Subscriber, WindowController):
         x = 10
 
         self.refresh()
-        if self.getItalicAngle() == 0 and CurrentFont() is not None:
-            self.setCrossHeight((CurrentFont().info.capHeight or 0) / 2)
 
     def makeReferenceLayerCallback(self, sender):
         setExtensionDefault(self.DEFAULTKEY_REFERENCE, sender.get())
 
     def italicizeCallback(self, sender=None):
+        self.setState()
         italicAngle = self.getItalicAngle()
         italicSlantOffset = self.getItalicSlantOffset()
         if self.w.fontSelection.get() == 0:
-            if CurrentFont() is not None:
-                fonts = [CurrentFont()]
+            if self.currentFont is not None:
+                fonts = [self.currentFont]
             else:
                 fonts = []
         else:
             fonts = AllFonts()
 
-        if self.w.glyphSelection.get() == 0 and CurrentGlyph() is not None:
-            glyphs = [CurrentGlyph()]
+        if self.w.glyphSelection.get() == 0 and self.currentGlyph is not None:
+            glyphs = [self.currentGlyph]
         elif self.w.glyphSelection.get() == 1:
             glyphs = []
             for f in fonts:
-                for gname in CurrentFont().selection:
+                for gname in self.currentFont.selection:
                     if gname in f:
                         glyphs.append(f[gname])
         else:
@@ -268,10 +296,10 @@ class ItalicBowtie(Subscriber, WindowController):
                       shouldMakeReferenceLayer=self.w.makeReferenceLayer.get())
 
     def refresh(self, sender=None):
-        f = CurrentFont()
-        if f:
-            italicSlantOffset = f.lib.get(self.italicSlantOffsetKey) or 0
-            italicAngle = f.info.italicAngle or 0
+        self.setState()
+        if self.currentFont:
+            italicSlantOffset = self.currentFont.lib.get(self.italicSlantOffsetKey) or 0
+            italicAngle = self.currentFont.info.italicAngle or 0
             crossHeight = calcCrossHeight(italicAngle=italicAngle,
                                                     italicSlantOffset=italicSlantOffset)
             self.setItalicSlantOffset(italicSlantOffset)
@@ -284,22 +312,19 @@ class ItalicBowtie(Subscriber, WindowController):
         self.updateBowtie()
 
     def setInFontCallback(self, sender):
+        fonts = []
         if self.w.fontSelection.get() == 0:
-            if CurrentFont() is not None:
-                fonts = [CurrentFont()]
-            else:
-                fonts = []
+            if self.currentFont is not None:
+                fonts.append(self.currentFont)
         else:
             fonts = AllFonts()
+        
         for f in fonts:
-            with f.undo('italicBowtie'):
-                f.info.italicAngle = self.getItalicAngle()
-                f.lib[self.italicSlantOffsetKey] = self.getItalicSlantOffset()
-        try:
-            window = CurrentGlyphWindow()
-            window.setGlyph(CurrentGlyph().naked())
-        except Exception:
-            print(self.DEFAULTKEY, 'error resetting window, please refresh it')
+            # IMPORTANT: set the lib first, then the italic angle, to get the change to show
+            f.lib[self.italicSlantOffsetKey] = self.getItalicSlantOffset()
+            f.info.italicAngle = self.getItalicAngle()
+            f.changed()
+            
         self.updateBowtie()
 
     def drawItalicBowtie(self, layer,
@@ -321,14 +346,15 @@ class ItalicBowtie(Subscriber, WindowController):
         pen.closePath()
 
     def calcItalicCallback(self, sender):
+        self.setState()
         italicAngle = self.getItalicAngle()
         italicSlantOffset = self.getItalicSlantOffset()
 
-        if sender == self.w.crossHeightSetUC and CurrentFont() is not None:
-            crossHeight = ( CurrentFont().info.capHeight or 0 ) / 2.0
+        if sender == self.w.crossHeightSetUC and self.currentFont is not None:
+            crossHeight = ( self.currentFont.info.capHeight or 0 ) / 2.0
             sender = self.w.crossHeight
-        elif sender == self.w.crossHeightSetLC and CurrentFont() is not None:
-            crossHeight = ( CurrentFont().info.xHeight or 0 ) / 2.0
+        elif sender == self.w.crossHeightSetLC and self.currentFont is not None:
+            crossHeight = ( self.currentFont.info.xHeight or 0 ) / 2.0
             sender = self.w.crossHeight
         else:
             crossHeight = self.getCrossHeight()
@@ -340,24 +366,25 @@ class ItalicBowtie(Subscriber, WindowController):
         self.updateBowtie()
 
     def updateBowtie(self):
-        glyph = CurrentGlyph()
-        italicAngle = self.getItalicAngle()
-        italicSlantOffset = self.getItalicSlantOffset()
-        crossHeight = self.getCrossHeight()
-        ascender = glyph.font.info.ascender
-        descender = glyph.font.info.descender
-        italicSlantOffsetOffset = italicSlantOffset
-        for xoffset, layer in [(0, self.leftBowtieLayer), (glyph.width, self.rightBowtieLayer)]:
-            self.drawItalicBowtie(layer=layer,
-                                  italicAngle=italicAngle,
-                                  crossHeight=crossHeight,
-                                  ascender=ascender,
-                                  descender=descender,
-                                  italicSlantOffset=italicSlantOffsetOffset,
-                                  xoffset=xoffset)
-        # crossheight
-        self.crossHeightLayer.setStartPoint((0, crossHeight))
-        self.crossHeightLayer.setEndPoint((glyph.width, crossHeight))
+        glyphEditor = CurrentGlyphWindow()
+        if self.currentGlyph is not None and glyphEditor is not None:
+            italicAngle = self.getItalicAngle()
+            italicSlantOffset = self.getItalicSlantOffset()
+            crossHeight = self.getCrossHeight()
+            ascender = self.currentFont.info.ascender
+            descender = self.currentFont.info.descender
+            italicSlantOffsetOffset = italicSlantOffset
+            for xoffset, layer in [(0, self.leftBowtieLayer), (self.currentGlyph.width, self.rightBowtieLayer)]:
+                self.drawItalicBowtie(layer=layer,
+                                    italicAngle=italicAngle,
+                                    crossHeight=crossHeight,
+                                    ascender=ascender,
+                                    descender=descender,
+                                    italicSlantOffset=italicSlantOffsetOffset,
+                                    xoffset=xoffset)
+            # crossheight
+            self.crossHeightLayer.setStartPoint((0, crossHeight))
+            self.crossHeightLayer.setEndPoint((self.currentGlyph.width, crossHeight))
 
     ################################
     ################################
@@ -396,4 +423,5 @@ class ItalicBowtie(Subscriber, WindowController):
 
 
 if __name__ == '__main__':
-    registerGlyphEditorSubscriber(ItalicBowtie)
+    if CurrentFont():
+        registerRoboFontSubscriber(ItalicBowtie)


### PR DESCRIPTION
Hi @djrrb (or whoever is maintaining this repo!),

I made a few edits to better manage the state of the tool.

- Will now only open one tool panel, instead of one for every glyph window (Fixes #29)
- Tool will now open if there is a font but no glyph window (useful for just quickly setting the values, and for Single Window Mode)
- Both italic angle AND offset will now show instantly after clicking "Set Font Italic Values", instead of having to click to another glyph
- "Values from Current Font" now more accurate (for some reason sometimes it would get values from a font that is not current)
- Shows the Current Font in the title bar of the panel
- Update certain methods like "move" to "moveBy" to remove the FontParts `DeprecationWarning`.
- Bumped version to 1.3

I hope these changes are acceptable, they solve a lot of issues that have come up with the tool recently.

(cc @typemytype @roberto-arista)